### PR TITLE
fix order of results to store from newest to oldest

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -79,7 +79,6 @@ const Home: NextPage = () => {
       const responseData = await response.json();
       const youtubeData = await getYoutubeSearchResults(responseData.result);
       setResults((prevState) => [
-        ...prevState,
         {
           prompt: {id: uuidv4(), message: userInput},
           res: {
@@ -88,6 +87,7 @@ const Home: NextPage = () => {
             video: youtubeData,
           },
         },
+        ...prevState,
       ]);
       setUserInput('');
     })();
@@ -102,7 +102,7 @@ const Home: NextPage = () => {
           userInput={userInput}
           setUserInput={setUserInput}
         />
-        {results.map(({prompt, res}) => (
+        {[...results].reverse().map(({prompt, res}) => (
           <React.Fragment key={uuidv4()}>
             <section key={prompt.id}>{prompt.message}</section>
             <section key={res.id}>{ShowResponse(res)}</section>


### PR DESCRIPTION
This commit fixes the order of the results state to have the newest result be at the front of the array, index 0, and the oldest to be at the end of the array. Rendering of the results array was reversed as I want the UI to be like a chat message having the newest message at the bottom and the view to scroll automatically as subsequent messages are sent through.